### PR TITLE
Fix: Prevent video distortion by changing `object-fit` to cover

### DIFF
--- a/src/components/VideoContainer.vue
+++ b/src/components/VideoContainer.vue
@@ -41,7 +41,7 @@ const props = defineProps(['videoPaths'])
     overflow: hidden;
 
     video {
-        object-fit: fill;
+        object-fit: cover;
         @include full-screen;
     }
 }


### PR DESCRIPTION
### Description
Changed the object-fit property from fill to cover for video elements. This change ensures that the video maintains its aspect ratio and does not appear distorted.

### Screenshots
#### Before:
![Crumpled Arona](https://github.com/user-attachments/assets/03827910-c3db-4d97-bb37-4e7fea8f3301)

#### After:
![Full-bloomed Arona](https://github.com/user-attachments/assets/e87a600a-4bc7-412e-b5c8-f1d7907708ad)
